### PR TITLE
Comparing dispatch_get_current_queue() with dispatch_get_main_queue()…

### DIFF
--- a/test/osx/dnode-objc/AppDelegate.m
+++ b/test/osx/dnode-objc/AppDelegate.m
@@ -32,7 +32,7 @@
 //server API ready 
 -(void)remoteReady
 {
-    NSAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"not running on main queue");
+    NSAssert([NSThread isMainThread], @"not running on main queue");
     NSLog(@"remoteReady");
 
     [_client foo];


### PR DESCRIPTION
… is not only deprecated since iOS6, but unreliable according to queue.h

When dispatch_get_current_queue() is called on the main thread, it may or may not return the same value as dispatch_get_main_queue(). Comparing the two is not a valid way to test whether code is executing on the main thread.
